### PR TITLE
feat: 카카오톡으로 로그인 구현

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "swimie",
     "slug": "swimie",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "swimie",
@@ -24,6 +24,7 @@
       }
     },
     "android": {
+      "versionCode": 3,
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#3B87F4"

--- a/app/(home)/index.tsx
+++ b/app/(home)/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { SafeAreaView, StyleSheet, Platform, StatusBar, BackHandler } from 'react-native';
+import { SafeAreaView, StyleSheet, Platform, StatusBar, BackHandler, Linking } from 'react-native';
 import WebView from 'react-native-webview';
 
 export default function HomeScreen() {
@@ -65,6 +65,13 @@ export default function HomeScreen() {
               setIsCanGoBack(state.canGoBack);
             }
           }
+        }}
+        onShouldStartLoadWithRequest={(event) => {
+          if(event.url.startsWith('kakaotalk')) {
+            Linking.openURL(event.url);
+            return false;
+          }
+          return true;
         }}
       />
     </SafeAreaView>


### PR DESCRIPTION
**Description**
- customUserAgent를 명확히 지정함에 따라, 모바일 웹 브라우저에서 나타나는 '카카오톡으로 로그인' 버튼이 활성화되었습니다.
- 웹뷰앱에서 이 버튼이 동작하려면 다른 앱을 열 수 있도록 추가적인 구현이 필요해 구현하였습니다.
- 카카오디벨로퍼스 앱을 비즈니스 앱으로 전환한 것과는 관련이 없었습니다.